### PR TITLE
fix swagger sym links. Rename basepath to apiurl. Remove express parameter.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 var fs = require('fs')
+var express = require('express')
 
 module.exports = function(opts){ 
   var app = opts.app
-  var express = opts.express
   var expressa = opts.expressa
 
   if( opts.description.match(/\.md$/) != null ){
@@ -18,7 +18,7 @@ module.exports = function(opts){
       "title": opts.title || "Api documentation", 
       "description": opts.description || "", 
     },
-    "basePath": opts.basepath || "/api",
+    "basePath": opts.apiurl || "/api",
     "schemes": opts.schemes || [ "http" ],
     "consumes": [ "application/json" ],
     "produces": [ "application/json" ],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/coderofsalvation/expressa-swagger#readme",
   "dependencies": {
+    "express": "^4.14.1",
     "swagger-ui": "^2.2.8"
   }
 }

--- a/public/doc/css
+++ b/public/doc/css
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/css
+../../../swagger-ui/dist/css

--- a/public/doc/fonts
+++ b/public/doc/fonts
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/fonts
+../../../swagger-ui/dist/fonts

--- a/public/doc/images
+++ b/public/doc/images
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/images
+../../../swagger-ui/dist/images

--- a/public/doc/lang
+++ b/public/doc/lang
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/lang
+../../../swagger-ui/dist/lang

--- a/public/doc/lib
+++ b/public/doc/lib
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/lib
+../../../swagger-ui/dist/lib

--- a/public/doc/o2c.html
+++ b/public/doc/o2c.html
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/o2c.html
+../../../swagger-ui/dist/o2c.html

--- a/public/doc/swagger-ui.js
+++ b/public/doc/swagger-ui.js
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/swagger-ui.js
+../../../swagger-ui/dist/swagger-ui.js

--- a/public/doc/swagger-ui.min.js
+++ b/public/doc/swagger-ui.min.js
@@ -1,1 +1,1 @@
-../../node_modules/swagger-ui/dist/swagger-ui.min.js
+../../../swagger-ui/dist/swagger-ui.min.js


### PR DESCRIPTION
I needed to update the symlinks as follows to work on my machine. Also, I'm not sure if symlinks is the best approach here since it definitely won't work on Windows. I'm not sure if there's a better way though.

I think basepath should be called apiurl for consistency with expressa. Then I changed it to require express so that you don't need to pass it.